### PR TITLE
Fix north-east panning

### DIFF
--- a/index.js
+++ b/index.js
@@ -49,7 +49,7 @@ export default class PinchZoomView extends Component {
 
   _handleMoveShouldSetPanResponder = (e, gestureState) => {
     return this.props.scalable 
-      && (gestureState.dx > 2 || gestureState.dy > 2 || gestureState.numberActiveTouches === 2);
+      && (Math.abs(gestureState.dx) > 2 || Math.abs(gestureState.dy) > 2 || gestureState.numberActiveTouches === 2);
   }
 
   _handlePanResponderGrant = (e, gestureState) => {


### PR DESCRIPTION
When panning north-east the x and y values will be negative, causing the pan gesture responder to never be set