### PR TITLE
Fix jump pan

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,7 +25,8 @@ export default class PinchZoomView extends Component {
       offsetX: 0,
       offsetY: 0,
       lastX: 0,
-      lastY: 0
+      lastY: 0,
+      lastMovePinch: false
     },
     this.distant = 150;
   }
@@ -77,12 +78,18 @@ export default class PinchZoomView extends Component {
       let distant = Math.sqrt(dx * dx + dy * dy);
       let scale = distant / this.distant * this.state.lastScale;
       this.setState({ scale });
+      this.setState({lastMovePinch: true});
     }
     // translate
     else if (gestureState.numberActiveTouches === 1) {
+      if (this.state.lastMovePinch) {
+        gestureState.dx = 0;
+        gestureState.dy = 0;
+      }
       let offsetX = this.state.lastX + gestureState.dx / this.state.scale;
       let offsetY = this.state.lastY + gestureState.dy / this.state.scale;
       this.setState({ offsetX, offsetY });
+      this.setState({lastMovePinch: false});
     }
   }
 

--- a/index.js
+++ b/index.js
@@ -77,8 +77,7 @@ export default class PinchZoomView extends Component {
       let dy = Math.abs(e.nativeEvent.touches[0].pageY - e.nativeEvent.touches[1].pageY);
       let distant = Math.sqrt(dx * dx + dy * dy);
       let scale = distant / this.distant * this.state.lastScale;
-      this.setState({ scale });
-      this.setState({lastMovePinch: true});
+      this.setState({ scale, lastMovePinch: true });
     }
     // translate
     else if (gestureState.numberActiveTouches === 1) {
@@ -88,8 +87,7 @@ export default class PinchZoomView extends Component {
       }
       let offsetX = this.state.lastX + gestureState.dx / this.state.scale;
       let offsetY = this.state.lastY + gestureState.dy / this.state.scale;
-      this.setState({ offsetX, offsetY });
-      this.setState({lastMovePinch: false});
+      this.setState({ offsetX, offsetY, lastMovePinch: false });
     }
   }
 


### PR DESCRIPTION
When pinching to zoom gestureState.dx and gestureState.dy would grow like normal causing it to jump pan once one of the two fingers was released if not a perfect zoom gesture was done.